### PR TITLE
clear quotes from enum, set values

### DIFF
--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -690,9 +690,13 @@ class MysqlCreateStatementFilter(object):
         column_definition_children_tokens.extend(
             self._skip_white_space_and_new_line_tokens(token_queue)
         )
-        column_type_length_token = self._create_column_type_length(token_queue)
-        if column_type_length_token:
-            column_definition_children_tokens.append(column_type_length_token)
+
+        if col_type_token.value == 'set' or col_type_token.value == 'enum':
+            column_type_meta_token = self._create_column_type_values(token_queue)
+        else:
+            column_type_meta_token = self._create_column_type_length(token_queue)
+        if column_type_meta_token:
+            column_definition_children_tokens.append(column_type_meta_token)
 
         column_definition_children_tokens.extend(
             self._skip_white_space_and_new_line_tokens(token_queue)
@@ -735,6 +739,18 @@ class MysqlCreateStatementFilter(object):
             parenthesis_token = token_queue.popleft()
             return sql.ColumnTypeLength(
                 tokens=parenthesis_token.tokens
+            )
+
+    def _create_column_type_values(self, token_queue):
+        if len(token_queue) <= 0:
+            return None
+        if isinstance(token_queue[0], sql.Parenthesis):
+            parenthesis_token = token_queue.popleft()
+            return sql.ColumnTypeValues(
+                tokens=[sql.Token(
+                    value=self._clean_quote(token.value),
+                    ttype=token.ttype
+                ) for token in parenthesis_token.tokens]
             )
 
     def _create_col_attrs_token(self, token_queue, col_type_token):

--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -691,13 +691,12 @@ class MysqlCreateStatementFilter(object):
             self._skip_white_space_and_new_line_tokens(token_queue)
         )
 
-        if (col_type_token.value.lower() == 'set' or
-                col_type_token.value.lower() == 'enum'):
-            column_type_meta_token = self._create_column_type_values(token_queue)
+        if col_type_token.value.lower() in ['set', 'enum']:
+            column_type_parenthesis_token = self._create_column_type_values(token_queue)
         else:
-            column_type_meta_token = self._create_column_type_length(token_queue)
-        if column_type_meta_token:
-            column_definition_children_tokens.append(column_type_meta_token)
+            column_type_parenthesis_token = self._create_column_type_length(token_queue)
+        if column_type_parenthesis_token:
+            column_definition_children_tokens.append(column_type_parenthesis_token)
 
         column_definition_children_tokens.extend(
             self._skip_white_space_and_new_line_tokens(token_queue)

--- a/sqlparse/filters.py
+++ b/sqlparse/filters.py
@@ -691,7 +691,8 @@ class MysqlCreateStatementFilter(object):
             self._skip_white_space_and_new_line_tokens(token_queue)
         )
 
-        if col_type_token.value == 'set' or col_type_token.value == 'enum':
+        if (col_type_token.value.lower() == 'set' or
+                col_type_token.value.lower() == 'enum'):
             column_type_meta_token = self._create_column_type_values(token_queue)
         else:
             column_type_meta_token = self._create_column_type_length(token_queue)
@@ -748,7 +749,7 @@ class MysqlCreateStatementFilter(object):
             parenthesis_token = token_queue.popleft()
             return sql.ColumnTypeValues(
                 tokens=[sql.Token(
-                    value=self._clean_quote(token.value),
+                    value=token.value.strip('`"\''),
                     ttype=token.ttype
                 ) for token in parenthesis_token.tokens]
             )

--- a/sqlparse/sql.py
+++ b/sqlparse/sql.py
@@ -702,6 +702,11 @@ class ColumnTypeLength(TokenList):
     __slots__ = ('value', 'ttype', 'tokens')
 
 
+class ColumnTypeValues(TokenList):
+
+    __slots__ = ('value', 'ttype', 'tokens')
+
+
 class Begin(TokenList):
     """A BEGIN/END block."""
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -487,7 +487,7 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         )
         if column_type_values_token is not None:
             return tuple(
-                column_type_values_token._remove_quotes(token.value)
+                token.value.strip('`"\'')
                 for token in column_type_values_token.tokens
                 if token.ttype is T.Literal.String.Single
             )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -137,75 +137,73 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         self._assert_equal_table_name(statement, u'abc')
         column_definitions = statement.token_next_by_instance(0, sql.ColumnsDefinition).tokens
         self.assertEqual(len(column_definitions), 10)
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[0],
             column_name=u'id',
             column_type=u'int',
             column_type_length=(u'11',),
             column_attributes=[(u'not null',), (u'auto_increment',)]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[1],
             column_name=u'name',
             column_type=u'varchar',
             column_type_length=(u'64',),
             column_attributes=[(u'collate', u'utf8_unicode_ci'), (u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[2],
             column_name=u'address',
             column_type=u'varchar',
             column_type_length=(u'128',),
             column_attributes=[(u'collate', u'utf8_unicode_ci'), (u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[3],
             column_name=u'related_id',
             column_type=u'int',
             column_type_length=(u'11',),
             column_attributes=[(u'not null',), (u'default', u'0',)]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[4],
             column_name=u'currency',
             column_type=u'double',
             column_type_length=(u'8', u'2'),
             column_attributes=[(u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[5],
             column_name=u'time_created',
             column_type=u'int',
             column_type_length=(u'11',),
             column_attributes=[(u'not null',), (u'default', u'0')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[6],
             column_name=u'age',
             column_type=u'int',
             column_type_length=(u'10',),
             column_attributes=[(u'unsigned',), (u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[7],
             column_name=u'type',
             column_type=u'tinyint',
             column_type_length=(u'3',),
             column_attributes=[(u'unsigned',), (u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_values(
             col_definition=column_definitions[8],
             column_name=u'size',
             column_type=u'enum',
-            column_type_length=None,
             column_type_values=('small', 'medium', 'large'),
             column_attributes=[(u'collate', u'utf8_unicode_ci'),]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_values(
             col_definition=column_definitions[9],
             column_name=u'teams',
             column_type=u'set',
-            column_type_length=None,
             column_type_values=('a', 'b', 'c'),
             column_attributes=[(u'collate', u'utf8_unicode_ci'),]
         )
@@ -218,21 +216,21 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         self._assert_equal_table_name(statement, u'abc')
         column_definitions = statement.token_next_by_instance(0, sql.ColumnsDefinition).tokens
         self.assertEqual(len(column_definitions), 3)
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[0],
             column_name=u'id',
             column_type=u'int',
             column_type_length=None,
             column_attributes=[(u'not null',), (u'auto_increment',)]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[1],
             column_name=u'age',
             column_type=u'int',
             column_type_length=None,
             column_attributes=[(u'default', u'null')]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[2],
             column_name=u'name',
             column_type=u'varchar',
@@ -248,40 +246,38 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         self._assert_equal_table_name(statement, u'abc')
         column_definitions = statement.token_next_by_instance(0, sql.ColumnsDefinition).tokens
         self.assertEqual(len(column_definitions), 5)
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[0],
             column_name=u'id',
             column_type=u'int',
             column_type_length=(u'11',),
             column_attributes=[]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[1],
             column_name=u'age',
             column_type=u'int',
             column_type_length=(u'11',),
             column_attributes=[]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition=column_definitions[2],
             column_name=u'name',
             column_type=u'varchar',
             column_type_length=(u'64',),
             column_attributes=[]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_values(
             col_definition=column_definitions[3],
             column_name=u'size',
             column_type=u'enum',
-            column_type_length=None,
             column_type_values=('small', 'medium', 'large'),
             column_attributes=[]
         )
-        self._assert_column_definition(
+        self._assert_column_definition_with_values(
             col_definition=column_definitions[4],
             column_name=u'teams',
             column_type=u'set',
-            column_type_length=None,
             column_type_values=('a', 'b', 'c'),
             column_attributes=[]
         )
@@ -322,19 +318,33 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
             expected_attributes=[]
         )
 
-    def test_clean_quotes(self):
+    def test_clean_identifiers_quotes(self):
         filter = sqlparse.filters.MysqlCreateStatementFilter()
-        assert filter._clean_quote('abc') == 'abc'
-        assert filter._clean_quote('"abc"') == 'abc'
-        assert filter._clean_quote('`ab``c`') == 'ab`c'
-        assert filter._clean_quote('"ab""c"') == 'ab"c'
-        assert filter._clean_quote('`ab""c`') == 'ab""c'
-        assert filter._clean_quote('"ab``c"') == 'ab``c'
-        assert filter._clean_quote('"ab""c"') == 'ab"c'
-        assert filter._clean_quote('`"abc"`') == '"abc"'
-        assert filter._clean_quote('"`abc`"') == '`abc`'
-        assert filter._clean_quote('`"a""b``c"`') == '"a""b`c"'
-        assert filter._clean_quote('"`a``b""c`"') == '`a``b"c`'
+        assert filter._clean_identifiers_quote('abc') == 'abc'
+        assert filter._clean_identifiers_quote('"abc"') == 'abc'
+        assert filter._clean_identifiers_quote('`ab``c`') == 'ab`c'
+        assert filter._clean_identifiers_quote('"ab""c"') == 'ab"c'
+        assert filter._clean_identifiers_quote('`ab""c`') == 'ab""c'
+        assert filter._clean_identifiers_quote('"ab``c"') == 'ab``c'
+        assert filter._clean_identifiers_quote('"ab""c"') == 'ab"c'
+        assert filter._clean_identifiers_quote('`"abc"`') == '"abc"'
+        assert filter._clean_identifiers_quote('"`abc`"') == '`abc`'
+        assert filter._clean_identifiers_quote('`"a""b``c"`') == '"a""b`c"'
+        assert filter._clean_identifiers_quote('"`a``b""c`"') == '`a``b"c`'
+
+    def test_string_quotes(self):
+        filter = sqlparse.filters.MysqlCreateStatementFilter()
+        assert filter._clean_string_quote('abc') == 'abc'
+        assert filter._clean_string_quote('"abc"') == 'abc'
+        assert filter._clean_string_quote('\'ab\'\'c\'') == 'ab\'c'
+        assert filter._clean_string_quote('"ab""c"') == 'ab"c'
+        assert filter._clean_string_quote('\'ab""c\'') == 'ab""c'
+        assert filter._clean_string_quote('"ab\'\'c"') == 'ab\'\'c'
+        assert filter._clean_string_quote('"ab""c"') == 'ab"c'
+        assert filter._clean_string_quote('\'"abc"\'') == '"abc"'
+        assert filter._clean_string_quote('"\'abc\'"') == '\'abc\''
+        assert filter._clean_string_quote('\'"a""b\'\'c"\'') == '"a""b\'c"'
+        assert filter._clean_string_quote('"\'a\'\'b""c\'"') == '\'a\'\'b"c\''
 
     def test_is_create_temp_table_stmt(self):
         sql_stmt = 'create temporary  table  `foo.``bar` (id int);'
@@ -426,7 +436,7 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         self.assertEqual(len(col_definitions), 1)
 
         col_definition = col_definitions[0]
-        self._assert_column_definition(
+        self._assert_column_definition_with_length(
             col_definition,
             expected_name,
             expected_type,
@@ -434,28 +444,41 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
             expected_attributes
         )
 
-    def _assert_column_definition(
+    def _assert_column_definition_with_length(
         self,
         col_definition,
         column_name,
         column_type,
         column_type_length,
-        column_attributes,
-        column_type_values=None
+        column_attributes
     ):
         assert isinstance(col_definition, sql.ColumnDefinition)
         self.assertEqual(self._get_column_name(col_definition), column_name)
         self.assertEqual(self._get_column_type(col_definition), column_type)
-        if column_type in ['enum', 'set']:
-            self.assertEqual(
-                self._get_column_type_values(col_definition),
-                column_type_values
-            )
-        else:
-            self.assertEqual(
-                self._get_column_type_length(col_definition),
-                column_type_length
-            )
+        self.assertEqual(
+            self._get_column_type_length(col_definition),
+            column_type_length
+        )
+        self.assertEqual(
+            self._get_column_attributes(col_definition),
+            column_attributes
+        )
+
+    def _assert_column_definition_with_values(
+        self,
+        col_definition,
+        column_name,
+        column_type,
+        column_type_values,
+        column_attributes
+    ):
+        assert isinstance(col_definition, sql.ColumnDefinition)
+        self.assertEqual(self._get_column_name(col_definition), column_name)
+        self.assertEqual(self._get_column_type(col_definition), column_type)
+        self.assertEqual(
+            self._get_column_type_values(col_definition),
+            column_type_values
+        )
         self.assertEqual(
             self._get_column_attributes(col_definition),
             column_attributes
@@ -486,8 +509,9 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
             0, sql.ColumnTypeValues
         )
         if column_type_values_token is not None:
+            filter = sqlparse.filters.MysqlCreateStatementFilter()
             return tuple(
-                token.value.strip('`"\'')
+                filter._clean_string_quote(token.value)
                 for token in column_type_values_token.tokens
                 if token.ttype is T.Literal.String.Single
             )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -446,7 +446,7 @@ class TestMysqlCreateStatementFilter(unittest.TestCase):
         assert isinstance(col_definition, sql.ColumnDefinition)
         self.assertEqual(self._get_column_name(col_definition), column_name)
         self.assertEqual(self._get_column_type(col_definition), column_type)
-        if column_type == 'enum' or column_type == 'set':
+        if column_type in ['enum', 'set']:
             self.assertEqual(
                 self._get_column_type_values(col_definition),
                 column_type_values


### PR DESCRIPTION
@premsantosh @clin7 

`ENUM` and `SET` create query consists of quotes around values, these need to be stripped in the tokens generated from sqlparser

```
CREATE TABLE shirts (
    name VARCHAR(40),
    size ENUM('x-small', 'small', 'medium', 'large', 'x-large')
);
```
### before

`('x-small', 'small', 'medium', 'large', 'x-large')` is of type `ColumnTypeLength`
### Now

`(x-small, small, medium, large, x-large)` is of type `ColumnTypeValues`

http://dev.mysql.com/doc/refman/5.7/en/enum.html
