### PR TITLE
Fix StopIteration runtime error for py37 above

### DIFF
--- a/sqlparse/engine/grouping.py
+++ b/sqlparse/engine/grouping.py
@@ -180,7 +180,7 @@ def group_identifier(tlist):
             else:
                 if isinstance(t, sql.Comment) and t.is_multiline():
                     yield t
-                raise StopIteration
+                return
 
     def _next_token(tl, i):
         # chooses the next token. if two tokens are found then the


### PR DESCRIPTION
### Summary
We got error `RuntimeError: generator raised StopIteration` for several integration tests in schematizer from `sqlparse`, which due to a change in Python https://peps.python.org/pep-0479/ 

I just apply the same change that had been done in upstream to fix this issue https://github.com/andialbrecht/sqlparse/pull/202, I hope this can fix the errors.

###Note to reviewer
For this PR I can't add reviewers and assignees bc I don't have write access to the repo. I checked the previous PRs, it seemed to be the same case, so tagging @mhaseebmlk and @gstarnberger (ppl i can find under github yelpcorp) for review