### PR TITLE
Remove outdated use_2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,11 +86,6 @@ Parsing::
 VERSION = get_version()
 
 
-kwargs = {}
-if sys.version_info[0] == 3:
-    kwargs['use_2to3'] = True
-
-
 setup(
     name='sqlparse',
     version=VERSION,
@@ -118,6 +113,5 @@ setup(
         'Topic :: Database',
         'Topic :: Software Development'
     ],
-    scripts=['bin/sqlformat'],
-    **kwargs
+    scripts=['bin/sqlformat']
 )

--- a/sqlparse/__init__.py
+++ b/sqlparse/__init__.py
@@ -6,7 +6,7 @@
 """Parse SQL statements."""
 
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'
 
 
 # Setup namespace


### PR DESCRIPTION
### Summary
We will want to build the wheel of this package and upload to Pypi, see some context in this ticket https://jira.yelpcorp.com/browse/STREAMINT-2208

I followed the similar process locally
```
2to3-3.7 -w --no-diffs -n sqlparse/  #convert code from py2 to py3
python3.7 setup.py bdist_wheel #build the wheel
pip install ../sqlparse/dist/sqlparse-0.1.15-py3-none-any.whl #install the wheel in local virtualenv
``` 
the tests passed with that local sqlparse package installed, so I assume it's working.

I encountered error `error in sqlparse setup command: use_2to3 is invalid.` when building the wheel and i think it's because the setuptools change https://setuptools.pypa.io/en/latest/history.html#v58-0-0 removed that support. If we follow the process described above we can convert the code use the `2to3` tools locally, so we can remove the conversion logic within the `setup.py`, the downside would be not being able to run `pip setup.py install` directly to install the package, which shouldn't be too big a deal, also we might as well need to upgrade this package to py3 if we want to maintain it properly.

cc @gstarnberger for review